### PR TITLE
fix: prevent autosave from overwriting submitted applications

### DIFF
--- a/src/hooks/use-applicant-autosave.ts
+++ b/src/hooks/use-applicant-autosave.ts
@@ -1,5 +1,5 @@
 import { useApplicantStore } from "@/lib/stores/applicant-store";
-import { createOrMergeApplicant } from "@/services/applicants";
+import { saveApplicantDraftSnapshot } from "@/services/applicants";
 import { useEffect, useState } from "react";
 
 const AUTOSAVE_INTERVAL = 5_000;
@@ -45,11 +45,14 @@ export function useApplicantAutosave(dbCollectionName: string, uid: string | und
 
       try {
         setSaving(true);
-        await createOrMergeApplicant(dbCollectionName, uid, applicantDraft);
+        await saveApplicantDraftSnapshot(dbCollectionName, uid, applicantDraft);
 
         // only clear dirty if no new edits occurred during the save
         const { applicantDraft: currentDraft } = useApplicantStore.getState();
-        setDirty(currentDraft !== applicantDraft);
+        const currentIsSubmitted =
+          currentDraft?.submission?.submitted === true ||
+          currentDraft?.status?.applicationStatus !== "inProgress";
+        setDirty(currentIsSubmitted ? false : currentDraft !== applicantDraft);
         setLastLocalSaveAt(Date.now());
       } catch (error) {
         console.error("applicant autosave failed", {

--- a/src/services/applicants.ts
+++ b/src/services/applicants.ts
@@ -82,6 +82,38 @@ export async function createOrMergeApplicant(
 }
 
 /**
+ * Saves an applicant draft snapshot to Firestore without touching submission state
+ *
+ * This is used by autosave/manual draft saves so stale draft writes cannot overwrite
+ * `submission.submitted`, `submission.submittedAt`, or `status.applicationStatus`
+ *
+ * @param dbCollectionName - firestore collection name for the hackathon
+ * @param uid - firebase auth user id (also used as the document id)
+ * @param draft - applicant draft snapshot to be merged
+ * @returns a promise that resolves when the applicant draft snapshot is merged
+ */
+export async function saveApplicantDraftSnapshot(
+  dbCollectionName: string,
+  uid: string,
+  draft: ApplicantDraft,
+): Promise<void> {
+  const ref = getApplicantRef(dbCollectionName, uid);
+
+  await setDoc(
+    ref,
+    {
+      _id: uid,
+      basicInfo: draft.basicInfo,
+      questionnaire: draft.questionnaire,
+      skills: draft.skills,
+      termsAndConditions: draft.termsAndConditions,
+      submission: { lastUpdated: serverTimestamp() as Timestamp },
+    },
+    { merge: true },
+  );
+}
+
+/**
  * Submits an applicant draft by marking it as submitted and persisting it.
  * Returns the updated draft shape that callers can use to update local state.
  */
@@ -140,7 +172,7 @@ export async function saveApplicantDraft(dbCollectionName: string): Promise<void
     return;
   }
 
-  await createOrMergeApplicant(dbCollectionName, user.uid, applicantDraft);
+  await saveApplicantDraftSnapshot(dbCollectionName, user.uid, applicantDraft);
   setDirty(false);
   setLastLocalSaveAt(Date.now());
 }


### PR DESCRIPTION
## Reason
there was a race condition where an in-flight autosave could overwrite submitted application state after the user submitted their application

found this after noticing some applicants had inconsistent submission state: `submission.submitted = false` and `status.applicationStatus = "inProgress"` while `submission.submittedAt` had a valid timestamp. that suggests submit had successfully written the timestamp, but a stale autosave landed afterward and reverted the submitted/status fields

## Explanation
<!--- Describe your changes! Include changes you made and screenshots/video if applicable -->
- autosave and manual draft saves now use a new `saveApplicantDraftSnapshot` helper instead of the general `createOrMergeApplicant` path. this helper only persists editable draft sections (`basicInfo`, `questionnaire`, `skills`, `termsAndConditions`) plus `_id` and `submission.lastUpdated`

- this prevents stale draft saves from overwriting submission-related fields like `submission.submitted`, `submission.submittedAt`, and `status.applicationStatus`. the submit flow still uses `createOrMergeApplicant`, so it remains responsible for setting submitted state and moving the application status to `applied`

- the autosave hook also clears dirty state when it sees that the current draft was submitted while an autosave was in flight